### PR TITLE
fix: cmk backup key is optional now

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ resource |
 | [random_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azuread_service_principal](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
-| [azuread_user] (https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone_virtual_network_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azuread_user](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ resource |
 | [azurerm_postgresql_flexible_server_firewall_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
 | [azurerm_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azuread_service_principal](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azuread_user] (https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+| [azurerm_private_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone_virtual_network_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,14 +59,14 @@ module "network" {
 
 module "postgresql" {
   source  = "cloudnationhq/psql/azure"
-  version = "~> 0.1"
+  version = "~> 0.2"
 
   naming = local.naming
 
   for_each = {
     for key, psql in local.postgresql_servers : key => psql
   }
-  postgresql = each.value
+  instance = each.value
 
   depends_on = [module.network]
 }
@@ -81,7 +81,7 @@ module "postgresql_replicas" {
   for_each = {
     for key, psql in local.postgresql_replicas : key => psql
   }
-  postgresql = each.value
+  instance = each.value
 
   depends_on = [module.postgresql]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -58,8 +58,7 @@ module "network" {
 }
 
 module "postgresql" {
-  source  = "cloudnationhq/psql/azure"
-  version = "~> 0.2"
+  source = "../.."
 
   naming = local.naming
 
@@ -73,8 +72,7 @@ module "postgresql" {
 
 
 module "postgresql_replicas" {
-  source  = "cloudnationhq/psql/azure"
-  version = "~> 0.1"
+  source = "../.."
 
   naming = local.naming
 

--- a/examples/customer-managed-key/main.tf
+++ b/examples/customer-managed-key/main.tf
@@ -108,7 +108,7 @@ module "postgresql" {
       primary = {
         key_vault_id     = module.kv.vault.id
         key_vault_key_id = module.kv.keys.psql.id
-      },
+      }
       backup = {
         key_vault_id     = module.kv_backup.vault.id
         key_vault_key_id = module.kv_backup.keys.psql.id

--- a/examples/fw-rules/locals.tf
+++ b/examples/fw-rules/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  naming = {
+    postgresql_database = module.naming.postgresql_database.name
+  }
+}

--- a/examples/multiple/main.tf
+++ b/examples/multiple/main.tf
@@ -18,8 +18,7 @@ module "rg" {
 }
 
 module "postgresql" {
-  source  = "cloudnationhq/psql/azure"
-  version = "~> 0.1"
+  source = "../.."
 
   naming        = local.naming
   resourcegroup = module.rg.groups.demo.name

--- a/examples/multiple/outputs.tf
+++ b/examples/multiple/outputs.tf
@@ -1,8 +1,7 @@
 output "instances" {
   value = {
     for inst_name, inst_config in local.instances : inst_name => {
-      name       = inst_config.name
-      #dns_prefix = inst_config.dns_prefix
+      name = inst_config.name
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,14 +1,14 @@
 locals {
   role_assignments = try(var.instance.cmk != null, false) ? {
     primary = var.instance.cmk.primary.key_vault_id
-    backup  = var.instance.cmk.backup.key_vault_id
+    backup  = try(var.instance.cmk.backup.key_vault_id, null)
   } : {}
 }
 
 locals {
   user_assigned_identities = try(var.instance.cmk != null, false) ? {
     primary = var.instance.cmk.primary != null ? { naming_suffix = "" } : null,
-    backup  = var.instance.cmk.backup != null ? { naming_suffix = "-bck" } : null
+    backup  = try(var.instance.cmk.backup, null) != null ? { naming_suffix = "-bck" } : null
   } : {}
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,15 +1,12 @@
 locals {
-  role_assignments = try(var.instance.cmk != null, false) ? {
-    primary = var.instance.cmk.primary.key_vault_id
-    try(var.instance.cmk.backup.key_vault_id, null) != null ? backup = var.instance.cmk.backup.key_vault_id : null
-  } : {}
-}
-
-locals {
-  user_assigned_identities = try(var.instance.cmk != null, false) ? {
-    primary = var.instance.cmk.primary != null ? { naming_suffix = "" } : null,
-    backup  = try(var.instance.cmk.backup, null) != null ? { naming_suffix = "-bck" } : null
-  } : {}
+  user_assigned_identities = flatten([for uai_key, uai in lookup(var.instance, "cmk", {}) :
+    {
+      key              = uai_key
+      naming_suffix    = uai_key == "backup" ? "-bck" : ""
+      key_vault_id     = uai.key_vault_id
+      key_vault_key_id = uai.key_vault_key_id
+    } if lookup(var.instance, "cmk", null) != null
+  ])
 }
 
 locals {

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   role_assignments = try(var.instance.cmk != null, false) ? {
     primary = var.instance.cmk.primary.key_vault_id
-    backup  = try(var.instance.cmk.backup.key_vault_id, null)
+    try(var.instance.cmk.backup.key_vault_id, null) != null ? backup = var.instance.cmk.backup.key_vault_id : null
   } : {}
 }
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql" {
   }
 
   lifecycle {
-    ignore_changes = [zone, high_availability.0.standby_availability_zone]
+    ignore_changes = [zone, high_availability[0].standby_availability_zone]
   }
 
   depends_on = [azurerm_role_assignment.identity_role_assignment]

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 data "azuread_service_principal" "current" {
-  for_each = try(var.instance.ad_admin.principal_type, null) == null || try(var.instance.ad_admin.principal_type, null) == "ServicePrincipal" ? { "id" = {} } : {}
+  for_each = try(var.instance.ad_admin.principal_type, null) == null && try(var.instance.ad_admin, null) != null || try(var.instance.ad_admin.principal_type, null) == "ServicePrincipal" ? { "id" = {} } : {}
 
   object_id = try(var.instance.ad_admin.principal_type, null) == null ? data.azurerm_client_config.current.object_id : try(var.instance.ad_admin.object_id, null)
 }
@@ -53,14 +53,14 @@ resource "azurerm_postgresql_flexible_server" "postgresql" {
   }
 
   dynamic "customer_managed_key" {
-    for_each = (try(var.instance.cmk.primary, null) != null || try(var.instance.cmk.backup, null) != null) ? [1] : []
+    for_each = (try(var.instance.cmk, null) != null) ? [1] : []
 
     content {
-      key_vault_key_id                  = try(var.instance.cmk.primary.key_vault_key_id, null)
+      key_vault_key_id                  = var.instance.cmk.primary.key_vault_key_id
       primary_user_assigned_identity_id = azurerm_user_assigned_identity.identity["primary"].id
 
       geo_backup_key_vault_key_id          = try(var.instance.cmk.backup.key_vault_key_id, null)
-      geo_backup_user_assigned_identity_id = azurerm_user_assigned_identity.identity["backup"].id
+      geo_backup_user_assigned_identity_id = try(azurerm_user_assigned_identity.identity["backup"].id, null)
     }
   }
 
@@ -102,17 +102,17 @@ resource "azurerm_postgresql_flexible_server" "postgresql" {
 
 # user assigned identities
 resource "azurerm_user_assigned_identity" "identity" {
-  for_each = local.user_assigned_identities
+  for_each = { for uai in local.user_assigned_identities : uai.key => uai }
 
-  name                = "uai-${var.instance.name}${each.value != null ? each.value.naming_suffix : ""}"
+  name                = "uai-${var.instance.name}${each.value.naming_suffix}"
   resource_group_name = var.instance.resource_group
   location            = var.instance.location
 }
 
 resource "azurerm_role_assignment" "identity_role_assignment" {
-  for_each = local.role_assignments
+  for_each = { for uai in local.user_assigned_identities : uai.key => uai }
 
-  scope                = each.value
+  scope                = each.value.key_vault_id
   role_definition_name = "Key Vault Crypto Officer"
   principal_id         = azurerm_user_assigned_identity.identity[each.key].principal_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "instance" {
   description = "describes psql server related configuration"
-  type = any
+  type        = any
 }
 
 variable "naming" {


### PR DESCRIPTION
- Changed locals to iterate and flatten through the CMK object, making the "backup" key optional instead of required. 
- Updated main.tf to use this new local object variable for user_assigned_identities and their respective role assignments. 
- Updated main.tf CMK block to make the "backup" block optional instead of required. 
- Updated examples to reflect changes of above. 
- Updated examples to update the variable _postgresql_server_ to _instance_ which got renamed in earlier version.